### PR TITLE
Fix unresizable empty script window

### DIFF
--- a/PendelChaosteheory/Script
+++ b/PendelChaosteheory/Script
@@ -506,7 +506,7 @@ class PendulumApp(object):
 
     def present(self):
         # present the assembled UI
-        self.view.present('sheet')
+        self.view.present('fullscreen', hide_title_bar=True)
 
 
 # Run the app


### PR DESCRIPTION
Change `present` method to use fullscreen to fix the unresizable and empty window issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-bfc0054d-de6c-4c1b-ad24-8bd25e232741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bfc0054d-de6c-4c1b-ad24-8bd25e232741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

