### PR TITLE
Set pendulum simulation domain, protect Wahl-page

### DIFF
--- a/pendel-web/Procfile
+++ b/pendel-web/Procfile
@@ -1,2 +1,2 @@
-web: streamlit run server/app_streamlit.py --server.port $PORT --server.headless true --server.address 0.0.0.0
+web: streamlit run server/app_streamlit.py --server.port $PORT --server.headless true --server.address 0.0.0.0 --server.baseUrlPath pendel
 

--- a/wahl-portal/next.config.ts
+++ b/wahl-portal/next.config.ts
@@ -1,8 +1,23 @@
-import type { NextConfig } from "next";
+declare const process: any;
+const pendelOrigin = process.env?.PENDEL_ORIGIN as string | undefined;
 
-const nextConfig: NextConfig = {
-  /* config options here */
+const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    if (!pendelOrigin) {
+      return [];
+    }
+    return [
+      {
+        source: "/pendel",
+        destination: `${pendelOrigin}/pendel`,
+      },
+      {
+        source: "/pendel/:path*",
+        destination: `${pendelOrigin}/pendel/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/wahl-portal/tsconfig.json
+++ b/wahl-portal/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["node"],
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
Proxy `/pendel` path to a separate Streamlit service to host the pendulum simulation as requested.

The user requested to host the pendulum simulation at `/pendel` without modifying existing Wahl-Portal pages. This PR implements a Next.js rewrite to proxy requests for `/pendel` to an external service (defined by `PENDEL_ORIGIN` environment variable), ensuring the Wahl-Portal's content remains untouched. The Streamlit app's `baseUrlPath` is also configured to correctly serve under the `/pendel` subpath.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6d9fec3-7fb9-4717-89ec-3c2aca9b114e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6d9fec3-7fb9-4717-89ec-3c2aca9b114e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

